### PR TITLE
Convert Polymorphic Variants to Ordinary Variants for Local Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## Build `pirc`
+## Install Dependencies
+
+```sh
+opam install . --deps-only --with-test
+```
+
+## Build pirc
 
 ```sh
 dune build
@@ -13,8 +19,21 @@ dune test
 ## Build and execute
 
 ```sh
+dune exec pirc -- [options] <file>
+```
+
+if it has been installed by `dune install` you can run it directly:
+
+```sh
+pirc [options] <file>
+``` 
+
+E.g.:
+
+```sh
 cd examples
-dune exec pirc <file>
+dune exec pirc -- -ast-dump json 1.pir
+pirc -ast-dump json 2.pir
 ```
 
 Then `pirc` will parse the file and dump the ASTs to the current directory (in pretty-printed format by default).

--- a/lib/ast/choreo.ml
+++ b/lib/ast/choreo.ml
@@ -33,7 +33,7 @@ type expr =
 
 and stmt =
   | Decl of pattern * typ
-  | Assign of pattern list * expr
+  | Assign of pattern list * expr (* list is only for F P1 P2 ... Pn := C *)
   | TypeDecl of Local.typ_id * typ
 
 and stmt_block = stmt list

--- a/lib/ast/local.ml
+++ b/lib/ast/local.ml
@@ -1,8 +1,7 @@
 type value =
-  [ `Int of int
-  | `String of string
-  | `Bool of bool
-  ]
+  | Int of int
+  | String of string
+  | Bool of bool
 
 type loc_id = LocId of string
 type var_id = VarId of string

--- a/lib/ast_utils/jsonify_ast.ml
+++ b/lib/ast_utils/jsonify_ast.ml
@@ -3,7 +3,14 @@
 let rec jsonify_local_expr (e : Ast.Local.expr) =
   match e with
   | Unit -> `String "Unit"
-  | Val ((`Int _ | `String _ | `Bool _) as v) -> `Assoc [ "Val", v ]
+  | Val v ->
+    `Assoc
+      [ ( "Val"
+        , match v with
+          | Int i -> `Int i
+          | String s -> `String s
+          | Bool b -> `Bool b )
+      ]
   | Var (VarId id) -> `Assoc [ "Var", `String id ]
   | Fst e -> `Assoc [ "Fst", jsonify_local_expr e ]
   | Snd e -> `Assoc [ "Snd", jsonify_local_expr e ]
@@ -45,7 +52,14 @@ and jsonify_local_case (p, e) =
 
 and jsonify_local_pattern = function
   | Default -> `String "Default"
-  | Val ((`Int _ | `String _ | `Bool _) as v) -> `Assoc [ "Val", v ]
+  | Val v ->
+    `Assoc
+      [ ( "Val"
+        , match v with
+          | Int i -> `Int i
+          | String s -> `String s
+          | Bool b -> `Bool b )
+      ]
   | Var (VarId id) -> `Assoc [ "Var", `String id ]
   | Left p -> `Assoc [ "Left", jsonify_local_pattern p ]
   | Right p -> `Assoc [ "Right", jsonify_local_pattern p ]

--- a/lib/ast_utils/pprint_ast.ml
+++ b/lib/ast_utils/pprint_ast.ml
@@ -25,9 +25,9 @@ let rec pprint_local_expr ppf (e : Ast.Local.expr) =
       ppf
       "@[<h>%a@]"
       (fun ppf -> function
-        | `Int i -> fprintf ppf "%d" i
-        | `String s -> fprintf ppf "\"%s\"" s
-        | `Bool b -> fprintf ppf "%b" b)
+        | Ast.Local.Int i -> fprintf ppf "%d" i
+        | String s -> fprintf ppf "\"%s\"" s
+        | Bool b -> fprintf ppf "%b" b)
       v
   | Var (VarId id) -> fprintf ppf "@[<h>%s@]" id
   | UnOp (op, e) ->
@@ -104,9 +104,9 @@ and pprint_local_pattern ppf = function
       ppf
       "@[<h>%a@]"
       (fun ppf -> function
-        | `Int i -> fprintf ppf "%d" i
-        | `String s -> fprintf ppf "%s" s
-        | `Bool b -> fprintf ppf "%b" b)
+        | Ast.Local.Int i -> fprintf ppf "%d" i
+        | String s -> fprintf ppf "%s" s
+        | Bool b -> fprintf ppf "%b" b)
       v
   | Var (VarId id) -> fprintf ppf "@[<h>%s@]" id
   | Pair (p1, p2) ->

--- a/lib/parsing/parser.mly
+++ b/lib/parsing/parser.mly
@@ -157,10 +157,10 @@ sync_label:
   | ID { LabelId $1 }
 
 value:
-  | INT    { `Int $1 }
-  | STRING { `String $1 }
-  | TRUE   { `Bool true }
-  | FALSE  { `Bool false }
+  | INT    { Int $1 }
+  | STRING { String $1 }
+  | TRUE   { Bool true }
+  | FALSE  { Bool false }
 
 %inline choreo_case:
   | VERTICAL choreo_pattern ARROW choreo_expr { ($2, $4) }

--- a/test/parsing_test.ml
+++ b/test/parsing_test.ml
@@ -26,7 +26,7 @@ let new_decl _ =
 let int_assign _ =
   peq
     "x := P1.5;"
-    (Prog [ Assign ([ Var (VarId "x") ], LocExpr (LocId "P1", Val (`Int 5))) ])
+    (Prog [ Assign ([ Var (VarId "x") ], LocExpr (LocId "P1", Val (Int 5))) ])
 ;;
 
 let decl_expr _ =
@@ -35,7 +35,7 @@ let decl_expr _ =
     (Prog
        [ Decl
            ( Pair
-               (LocPatt (LocId "P1", Val (`Int 5)), LocPatt (LocId "P2", Val (`Bool true)))
+               (LocPatt (LocId "P1", Val (Int 5)), LocPatt (LocId "P2", Val (Bool true)))
            , TProd (TLoc (LocId "P1", TInt), TLoc (LocId "P2", TBool)) )
        ])
 ;;
@@ -47,7 +47,7 @@ let pair_assign _ =
        [ Assign
            ( [ Var (VarId "pair1") ]
            , Pair
-               (LocExpr (LocId "P1", Val (`Int 5)), LocExpr (LocId "P2", Val (`Bool true)))
+               (LocExpr (LocId "P1", Val (Int 5)), LocExpr (LocId "P2", Val (Bool true)))
            )
        ])
 ;;
@@ -62,11 +62,11 @@ let binary_operation _ =
                ( LocExpr
                    ( LocId "P1"
                    , BinOp
-                       ( BinOp (Val (`Int 3), Gt, Val (`Int 5))
+                       ( BinOp (Val (Int 3), Gt, Val (Int 5))
                        , And
-                       , BinOp (Val (`Int 4), Lt, Val (`Int 0)) ) )
-               , LocExpr (LocId "P1", Val (`Int 3))
-               , LocExpr (LocId "P1", Val (`Int 6)) ) )
+                       , BinOp (Val (Int 4), Lt, Val (Int 0)) ) )
+               , LocExpr (LocId "P1", Val (Int 3))
+               , LocExpr (LocId "P1", Val (Int 6)) ) )
        ])
 ;;
 
@@ -78,8 +78,8 @@ let test_first_pair _ =
            ( [ Var (VarId "y") ]
            , Fst
                (Pair
-                  ( LocExpr (LocId "P1", Val (`String "Hello"))
-                  , LocExpr (LocId "P1", Val (`String "World")) )) )
+                  ( LocExpr (LocId "P1", Val (String "Hello"))
+                  , LocExpr (LocId "P1", Val (String "World")) )) )
        ])
 ;;
 
@@ -91,8 +91,8 @@ let test_second_pair _ =
            ( [ Var (VarId "y") ]
            , Snd
                (Pair
-                  ( LocExpr (LocId "P1", Val (`String "Hello"))
-                  , LocExpr (LocId "P1", Val (`String "World")) )) )
+                  ( LocExpr (LocId "P1", Val (String "Hello"))
+                  , LocExpr (LocId "P1", Val (String "World")) )) )
        ])
 ;;
 
@@ -103,7 +103,7 @@ let test_decl_send _ =
        [ Decl (Var (VarId "y"), TLoc (LocId "P2", TInt))
        ; Assign
            ( [ Var (VarId "y") ]
-           , Send (LocId "P1", LocExpr (LocId "P1", Val (`Int 5)), LocId "P2") )
+           , Send (LocId "P1", LocExpr (LocId "P1", Val (Int 5)), LocId "P2") )
        ])
 ;;
 


### PR DESCRIPTION
Previously, local values were unnecessarily defined using Polymorphic variants, which added complexity to the code and potentially impacted type discipline and performance. This change simplifies the code by using standard variants instead.