### PR TITLE
Remove TAlias

### DIFF
--- a/lib/ast/choreo.ml
+++ b/lib/ast/choreo.ml
@@ -4,7 +4,6 @@ type typ =
   | TMap of typ * typ
   | TProd of typ * typ
   | TSum of typ * typ
-  | TAlias of Local.typ_id * typ
 
 type pattern =
   | Default

--- a/lib/ast_utils/ast_locs.ml
+++ b/lib/ast_utils/ast_locs.ml
@@ -43,5 +43,4 @@ and extract_type = function
   | TLoc (LocId id, _) -> LocSet.singleton id
   | TMap (t1, t2) | TProd (t1, t2) | TSum (t1, t2) ->
     LocSet.union (extract_type t1) (extract_type t2)
-  | TAlias (_, t) -> extract_type t
 ;;

--- a/lib/ast_utils/jsonify_ast.ml
+++ b/lib/ast_utils/jsonify_ast.ml
@@ -216,8 +216,6 @@ and jsonify_choreo_type = function
     `Assoc [ "TProd", `List [ jsonify_choreo_type t1; jsonify_choreo_type t2 ] ]
   | TSum (t1, t2) ->
     `Assoc [ "TSum", `List [ jsonify_choreo_type t1; jsonify_choreo_type t2 ] ]
-  | TAlias (TypId id, t) ->
-    `Assoc [ "TAlias", `Assoc [ "id", `String id; "choreo_type", jsonify_choreo_type t ] ]
 ;;
 
 (* ============================== Net ============================== *)

--- a/lib/ast_utils/pprint_ast.ml
+++ b/lib/ast_utils/pprint_ast.ml
@@ -269,7 +269,6 @@ and pprint_choreo_type ppf = function
     fprintf ppf "@[<h>(%a) * (%a)@]" pprint_choreo_type t1 pprint_choreo_type t2
   | TSum (t1, t2) ->
     fprintf ppf "@[<h>(%a) + (%a)@]" pprint_choreo_type t1 pprint_choreo_type t2
-  | TAlias (TypId id, t) -> fprintf ppf "@[<h>type %s := %a;@]" id pprint_choreo_type t
 ;;
 
 (* ============================== Net ============================== *)


### PR DESCRIPTION
We already have `TypeDecl` as the syntax for type aliases, so there is no need of `TAlias`. Type alias info should be handled during type checking.