### PR TITLE
Revert change on if, fix func application

### DIFF
--- a/lib/codegen/emit_core.ml
+++ b/lib/codegen/emit_core.ml
@@ -66,10 +66,10 @@ let rec emit_local_pexp (expr : 'a Local.expr) =
     let cases =
       List.map
         (fun (p, e) ->
-          Ast_builder.Default.case
-            ~lhs:(emit_local_ppat p)
-            ~guard:None
-            ~rhs:(emit_local_pexp e))
+           Ast_builder.Default.case
+             ~lhs:(emit_local_ppat p)
+             ~guard:None
+             ~rhs:(emit_local_pexp e))
         cases
     in
     Ast_builder.Default.pexp_match ~loc (emit_local_pexp e) cases
@@ -87,10 +87,10 @@ and emit_local_ppat (pat : 'a Local.pattern) =
 ;;
 
 let rec emit_net_fun_body
-  ~(self_id : string)
-  (module Msg : Msg_intf)
-  (pats : 'a Local.pattern list)
-  (exp : 'a Net.expr)
+          ~(self_id : string)
+          (module Msg : Msg_intf)
+          (pats : 'a Local.pattern list)
+          (exp : 'a Net.expr)
   =
   match pats with
   | [] -> emit_net_pexp ~self_id (module Msg : Msg_intf) exp
@@ -149,23 +149,13 @@ and emit_net_pexp ~(self_id : string) (module Msg : Msg_intf) (exp : 'a Net.expr
       (emit_net_pexp ~self_id (module Msg) e)
   | FunDef (ps, e, _) -> emit_net_fun_body ~self_id (module Msg) ps e
   | FunApp (e1, e2, _) ->
-    let exception UnitFunction in
-    let[@specialise] rec check_unit : 'a Net.expr -> unit = function
-      | Unit _ -> raise UnitFunction
-      | FunApp (e1, _, _) -> check_unit e1
-      | _ -> ()
-    in
-    (try
-       check_unit e1;
-       [%expr
-         [%e emit_net_pexp ~self_id (module Msg) e1]
-           [%e emit_net_pexp ~self_id (module Msg) e2]]
-     with
-     | UnitFunction -> [%expr ()])
+    [%expr
+      [%e emit_net_pexp ~self_id (module Msg) e1]
+        [%e emit_net_pexp ~self_id (module Msg) e2]]
   | Pair (e1, e2, _) ->
     [%expr
       [%e emit_net_pexp ~self_id (module Msg) e1]
-      , [%e emit_net_pexp ~self_id (module Msg) e2]]
+    , [%e emit_net_pexp ~self_id (module Msg) e2]]
   | Fst (e, _) -> [%expr fst [%e emit_net_pexp ~self_id (module Msg) e]]
   | Snd (e, _) -> [%expr snd [%e emit_net_pexp ~self_id (module Msg) e]]
   | Left (e, _) -> [%expr Either.Left [%e emit_net_pexp ~self_id (module Msg) e]]
@@ -174,10 +164,10 @@ and emit_net_pexp ~(self_id : string) (module Msg : Msg_intf) (exp : 'a Net.expr
     let cases =
       List.map
         (fun (p, e) ->
-          Ast_builder.Default.case
-            ~lhs:(emit_local_ppat p)
-            ~guard:None
-            ~rhs:(emit_net_pexp ~self_id (module Msg) e))
+           Ast_builder.Default.case
+             ~lhs:(emit_local_ppat p)
+             ~guard:None
+             ~rhs:(emit_net_pexp ~self_id (module Msg) e))
         cases
     in
     Ast_builder.Default.pexp_match ~loc (emit_net_pexp ~self_id (module Msg) e) cases
@@ -208,16 +198,16 @@ and emit_net_pexp ~(self_id : string) (module Msg : Msg_intf) (exp : 'a Net.expr
     let cases =
       List.map
         (fun (Local.LabelId (label, _), e) ->
-          Ast_builder.Default.case
-            ~lhs:(Ast_builder.Default.pstring ~loc label)
-            ~guard:None
-            ~rhs:(emit_net_pexp ~self_id (module Msg) e))
+           Ast_builder.Default.case
+             ~lhs:(Ast_builder.Default.pstring ~loc label)
+             ~guard:None
+             ~rhs:(emit_net_pexp ~self_id (module Msg) e))
         cases
     and default_case =
       Ast_builder.Default.case
         ~lhs:(Ast_builder.Default.ppat_any ~loc)
         ~guard:None
-        ~rhs:[%expr failwith "Error: Unmatched label"]
+        ~rhs:[%expr failwith "Runtime Error: Unmatched label"]
     in
     Ast_builder.Default.pexp_match
       ~loc

--- a/lib/netgen/netgen.ml
+++ b/lib/netgen/netgen.ml
@@ -160,9 +160,10 @@ and epp_choreo_expr (expr : 'a Choreo.expr) (loc : string) : 'a Net.expr =
   | FunDef (ps, e, _) ->
     FunDef (List.map (fun p -> epp_choreo_pattern p loc) ps, epp_choreo_expr e loc, _m)
   | FunApp (e1, e2, _) ->
-    (match e1 with
+    let epp_e1 = epp_choreo_expr e1 loc in
+    (match epp_e1 with
      | Unit _m -> Unit _m
-     | _ -> FunApp (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, _m))
+     | _ -> FunApp (epp_e1, epp_choreo_expr e2 loc, _m))
   | Pair (e1, e2, _) -> Pair (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, _m)
   | Fst (e, _) -> Fst (epp_choreo_expr e loc, _m)
   | Snd (e, _) -> Snd (epp_choreo_expr e loc, _m)

--- a/lib/netgen/netgen.ml
+++ b/lib/netgen/netgen.ml
@@ -159,7 +159,10 @@ and epp_choreo_expr (expr : 'a Choreo.expr) (loc : string) : 'a Net.expr =
   | LocExpr (LocId (loc1, _), e, _) when loc1 = loc -> Ret (e, _m)
   | FunDef (ps, e, _) ->
     FunDef (List.map (fun p -> epp_choreo_pattern p loc) ps, epp_choreo_expr e loc, _m)
-  | FunApp (e1, e2, _) -> FunApp (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, _m)
+  | FunApp (e1, e2, _) ->
+    (match e1 with
+     | Unit _m -> Unit _m
+     | _ -> FunApp (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, _m))
   | Pair (e1, e2, _) -> Pair (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, _m)
   | Fst (e, _) -> Fst (epp_choreo_expr e loc, _m)
   | Snd (e, _) -> Snd (epp_choreo_expr e loc, _m)
@@ -187,10 +190,7 @@ and epp_choreo_expr (expr : 'a Choreo.expr) (loc : string) : 'a Net.expr =
     (match merge_net_expr (epp_choreo_expr e2 loc) (epp_choreo_expr e3 loc) with
      | Some e -> e
      | None ->
-       let condition = epp_choreo_expr e1 loc in
-       (match condition with
-        | Unit _ -> Unit _m
-        | _ -> If (condition, epp_choreo_expr e2 loc, epp_choreo_expr e3 loc, _m)))
+       If (epp_choreo_expr e1 loc, epp_choreo_expr e2 loc, epp_choreo_expr e3 loc, _m))
   | Match (match_e, cases, _) ->
     let merged_cases =
       match cases with


### PR DESCRIPTION
- The empty condition on `If` only appears when the `if` expr is not well-merged, it's not a bug in the compiler.

- Fix the bug in EPP function application `unit expr`.
